### PR TITLE
Fix the `get_proto()` chain extension method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 
 sp-fragnova = { version = '0.1.0', default-features = false }
 # We use this dependency to prevent the error "`#[global_allocator]` in ink_allocator conflicts with global allocator in: sp_io". This solution was found from https://substrate.stackexchange.com/questions/4733/error-when-compiling-a-contract-using-the-xcm-chain-extension
-sp-io = { version = '6.0.0', default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"], git = 'https://github.com/fragcolor-xyz/substrate.git', tag = 'fragnova-v0.0.6' }
+sp-io = { version = '6.0.0', default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
 
 protos = { version = "0.1.26", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ ink_prelude = { version = "3.3", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] } # this package is named "codec" when used in Fragnova (https://github.com/fragcolor-xyz/fragnova)
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-sp-fragnova = { version = '0.1.0', default-features = false, git = 'https://github.com/fragcolor-xyz/fragnova.git', branch = 'add-chain-extension' }
+sp-fragnova = { version = '0.1.0', default-features = false }
 # We use this dependency to prevent the error "`#[global_allocator]` in ink_allocator conflicts with global allocator in: sp_io". This solution was found from https://substrate.stackexchange.com/questions/4733/error-when-compiling-a-contract-using-the-xcm-chain-extension
 sp-io = { version = '6.0.0', default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"], git = 'https://github.com/fragcolor-xyz/substrate.git', tag = 'fragnova-v0.0.6' }
 
-protos = { version = "0.1.26", default-features = false, git = 'https://github.com/fragcolor-xyz/protos.git', branch = 'implement-maxencodedlen-trait-for-fragmentperms' }
+protos = { version = "0.1.26", default-features = false }
 
 [lib]
 name = "fragnova_extensions"

--- a/lib.rs
+++ b/lib.rs
@@ -66,8 +66,8 @@ pub trait MyChainExtension {
 	// Chain extension methods that access the protos pallet are prefixied with 0x0b (this is the same number as the pallet's index)
 	/// Get the `Proto` struct of the Proto-Fragment which has an ID of `proto_hash`
 	#[ink(extension = 0x0b00, handle_status = false, returns_result = false)]
-	/// Get the list of Proto-Fragments that are owned by `owner`
 	fn get_proto(proto_hash: Hash256) -> Option<Proto<AccountId, BlockNumber>>;
+	/// Get the list of Proto-Fragments that are owned by `owner`
 	#[ink(extension = 0x0b01, handle_status = false, returns_result = false)]
 	fn get_proto_ids(owner: AccountId) -> Vec<Hash256>;
 


### PR DESCRIPTION
The macro `#[ink::chain_extension]` was not immediately below the `get_proto()` function. 